### PR TITLE
Make SQLite Database Directory Configurable

### DIFF
--- a/src/Sejil.Server/Configuration/Internal/ISejilSettings.cs
+++ b/src/Sejil.Server/Configuration/Internal/ISejilSettings.cs
@@ -24,5 +24,11 @@ namespace Sejil.Configuration.Internal
         /// Gets or sets the authentication scheme, used for the index page. Leave empty for no authentication.
         /// </summary>
         string AuthenticationScheme { get; set; }
+
+        /// <summary>
+        /// Set the directory the sqlite log db is placed in
+        /// </summary>
+        /// <param name="directoryPath"></param>
+        void SetSqliteDbDirectory(string directoryPath);
     }
 }

--- a/src/Sejil.Server/Configuration/Internal/SejilSettings.cs
+++ b/src/Sejil.Server/Configuration/Internal/SejilSettings.cs
@@ -30,6 +30,8 @@ namespace Sejil.Configuration.Internal
         /// </summary>
         public string AuthenticationScheme { get; set; }
 
+        private string DbFileName => $"Sejil-{UUID}.sqlite";
+
         public SejilSettings(string uri, LogEventLevel minLogLevel)
         {
             SejilAppHtml = ResourceHelper.GetEmbeddedResource("Sejil.index.html");
@@ -43,17 +45,22 @@ namespace Sejil.Configuration.Internal
             {
                 // If running in azure, we won't use local app folder as its temporary and will frequently be deleted.
                 // Use home folder instead.
-                SqliteDbPath = Path.Combine(Path.GetFullPath("/home"), $"Sejil-{UUID}.sqlite");
+                SqliteDbPath = Path.Combine(Path.GetFullPath("/home"), DbFileName);
             }
             else
             {
                 var localAppFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                 var appName = Assembly.GetEntryAssembly().GetName().Name;
-                SqliteDbPath = Path.Combine(localAppFolder, appName, $"Sejil-{UUID}.sqlite");
+                SqliteDbPath = Path.Combine(localAppFolder, appName, DbFileName);
             }
 
             NonPropertyColumns = new[] { "message", "messageTemplate", "level", "timestamp", "exception" };
             PageSize = 100;
+        }
+
+        public void SetSqliteDbDirectory(string directoryPath)
+        {
+            SqliteDbPath = Path.Combine(directoryPath, DbFileName);
         }
 
         public bool TrySetMinimumLogLevel(string minLogLevel)

--- a/test/Sejil.Server.Test/Configuration/SejilSettingsTests.cs
+++ b/test/Sejil.Server.Test/Configuration/SejilSettingsTests.cs
@@ -73,6 +73,18 @@ namespace Sejil.Test.Configuration
             Assert.Equal(100, settings.PageSize);
         }
 
+        [Fact]
+        public void SetSqliteDbDirectory_ensure_SqliteDbPath_is_changed()
+        {
+            // Arrange & act
+            var settings = new SejilSettings("", LogEventLevel.Debug);
+
+            settings.SetSqliteDbDirectory(@"C:\Temp");
+
+            // Assert
+            Assert.Matches(@"^C:\\Temp\\Sejil-[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}\.sqlite$", settings.SqliteDbPath);
+        }
+
         [Theory]
         [InlineData("Trace", LogEventLevel.Verbose, true)]
         [InlineData("verbose", LogEventLevel.Verbose, true)]


### PR DESCRIPTION
Added SetSqliteDbDirectory(string directoryPath) on SejilSettings / ISejilSettings + wrote a UnitTest to validate it really generates the correct path later on.

I added this as a function instead of an additional property like `SqliteDbDirectory` as the `SqliteDbPath` is computed in the constructor of `SejilSettings` and i didn´t want to introduce a property setter with side effects (bad software design) and did not want to regenerate `SqliteDbPath` in the getter every time it´s accesed (performance)